### PR TITLE
Update query parameters in DbConfig to use id_eql instead of id_cont

### DIFF
--- a/app/avo/resources/db_config.rb
+++ b/app/avo/resources/db_config.rb
@@ -5,7 +5,7 @@ class Avo::Resources::DbConfig < Avo::BaseResource
     query: -> {
       query.ransack(
         key_cont: q,
-        id_cont: q,
+        id_eql: q,
         value_cont: q,
         value_type_cont: q,
         eager_load_cont: q,


### PR DESCRIPTION
Fixes:

```
PG::UndefinedFunction: ERROR:  operator does not exist: bigint ~~* unknown
LINE 1: ..."."key" ILIKE '%asd%' OR "db_config_records"."id" ILIKE '%0%...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```